### PR TITLE
Core functionality for using arbitrary shell scripts as migrations

### DIFF
--- a/flyway-ant-largetest/pom.xml
+++ b/flyway-ant-largetest/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>3.2.1-rollbar1</version>
     </parent>
     <artifactId>flyway-ant-largetest</artifactId>
     <packaging>jar</packaging>

--- a/flyway-ant/pom.xml
+++ b/flyway-ant/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>3.2.1-rollbar1</version>
     </parent>
     <artifactId>flyway-ant</artifactId>
     <packaging>jar</packaging>

--- a/flyway-ant/src/main/java/org/flywaydb/ant/AbstractFlywayTask.java
+++ b/flyway-ant/src/main/java/org/flywaydb/ant/AbstractFlywayTask.java
@@ -400,6 +400,13 @@ public abstract class AbstractFlywayTask extends Task {
     }
 
     /**
+     * @param shellMigrationArgs The arguments to be passed to shell migrations<br>Also configurable with Ant Property: ${flyway.shellMigrationArgs}
+     */
+    public void setShellMigrationArgs(String shellMigrationArgs) {
+        flyway.setShellMigrationArgs(shellMigrationArgs);
+    }
+
+    /**
      * @param target The target version up to which Flyway should consider migrations.
      *               Migrations with a higher version number will be ignored.
      *               The special value {@code current} designates the current version of the schema. (default: the latest version)<br>Also configurable with Ant Property: ${flyway.target}

--- a/flyway-ant/src/main/java/org/flywaydb/ant/AbstractFlywayTask.java
+++ b/flyway-ant/src/main/java/org/flywaydb/ant/AbstractFlywayTask.java
@@ -370,6 +370,36 @@ public abstract class AbstractFlywayTask extends Task {
     }
 
     /**
+     * <p>Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.shell</p>
+     *
+     * @param shellMigrationPrefix The file name prefix for shell migrations (default: V)<br>Also configurable with Ant Property: ${flyway.shellMigrationPrefix}
+     */
+    public void setShellMigrationPrefix(String shellMigrationPrefix) {
+        flyway.setShellMigrationPrefix(shellMigrationPrefix);
+    }
+
+    /**
+     * <p>Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.shell</p>
+     *
+     * @param shellMigrationSeparator The file name separator for shell migrations (default: V)<br>Also configurable with Ant Property: ${flyway.shellMigrationSeparator}
+     */
+    public void setShellMigrationSeparator(String shellMigrationSeparator) {
+        flyway.setShellMigrationSeparator(shellMigrationSeparator);
+    }
+
+    /**
+     * <p>Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.shell</p>
+     *
+     * @param shellMigrationSuffix The file name suffix for shell migrations (default: .sql)<br>Also configurable with Ant Property: ${flyway.shellMigrationSuffix}
+     */
+    public void setShellMigrationSuffix(String shellMigrationSuffix) {
+        flyway.setShellMigrationSuffix(shellMigrationSuffix);
+    }
+
+    /**
      * @param target The target version up to which Flyway should consider migrations.
      *               Migrations with a higher version number will be ignored.
      *               The special value {@code current} designates the current version of the schema. (default: the latest version)<br>Also configurable with Ant Property: ${flyway.target}

--- a/flyway-commandline-largetest/pom.xml
+++ b/flyway-commandline-largetest/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>3.2.1-rollbar1</version>
     </parent>
     <artifactId>flyway-commandline-largetest</artifactId>
     <packaging>jar</packaging>

--- a/flyway-commandline/pom.xml
+++ b/flyway-commandline/pom.xml
@@ -1,5 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <!--
     Detailed information how to contribute: http://flywaydb.org/contribute/code/
 
@@ -13,7 +12,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>3.2.1-rollbar1</version>
     </parent>
     <artifactId>flyway-commandline</artifactId>
     <packaging>jar</packaging>

--- a/flyway-commandline/src/main/assembly/component.xml
+++ b/flyway-commandline/src/main/assembly/component.xml
@@ -63,6 +63,14 @@
         </fileSet>
         <fileSet>
             <directory>src/main/assembly</directory>
+            <outputDirectory>/scripts</outputDirectory>
+            <includes>
+                <include>put-your-shell-script-migrations-here.txt</include>
+            </includes>
+            <fileMode>644</fileMode>
+        </fileSet>
+        <fileSet>
+            <directory>src/main/assembly</directory>
             <outputDirectory>/jars</outputDirectory>
             <includes>
                 <include>put-your-java-migration-jars-here.txt</include>

--- a/flyway-commandline/src/main/assembly/flyway.conf
+++ b/flyway-commandline/src/main/assembly/flyway.conf
@@ -84,6 +84,21 @@ flyway.password=
 # which using the defaults translates to V1_1__My_description.sql
 # flyway.sqlMigrationSuffix=
 
+# File name prefix for shell migrations (default: V )
+# Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+# which using the defaults translates to V1_1__My_description.shell
+# flyway.shellMigrationPrefix=
+
+# File name separator for shell migrations (default: __)
+# Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+# which using the defaults translates to V1_1__My_description.shell
+# flyway.shellMigrationSeparator=
+
+# File name suffix for shell migrations (default: .shell)
+# Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+# which using the defaults translates to V1_1__My_description.shell
+# flyway.shellMigrationSuffix=
+
 # Encoding of Sql migrations (default: UTF-8)
 # flyway.encoding=
 

--- a/flyway-commandline/src/main/assembly/flyway.conf
+++ b/flyway-commandline/src/main/assembly/flyway.conf
@@ -99,6 +99,9 @@ flyway.password=
 # which using the defaults translates to V1_1__My_description.shell
 # flyway.shellMigrationSuffix=
 
+# Arguments to be passed to shell migrations
+# flyway.shellMigrationArgs=
+
 # Encoding of Sql migrations (default: UTF-8)
 # flyway.encoding=
 

--- a/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
+++ b/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
@@ -157,7 +157,8 @@ public class Main {
      * @param properties The properties object to initialize.
      */
     private static void initializeDefaults(Properties properties) {
-        properties.put("flyway.locations", "filesystem:" + new File(getInstallationDir(), "sql").getAbsolutePath());
+        properties.put("flyway.locations", "filesystem:" + new File(getInstallationDir(), "sql").getAbsolutePath()
+                + ",filesystem:" + new File(getInstallationDir(), "scripts").getAbsolutePath());
         properties.put("flyway.jarDirs", new File(getInstallationDir(), "jars").getAbsolutePath());
     }
 

--- a/flyway-core/pom.xml
+++ b/flyway-core/pom.xml
@@ -1,5 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <!--
     Detailed information how to contribute: http://flywaydb.org/contribute/code/
 
@@ -21,7 +20,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>3.2.1-rollbar1</version>
     </parent>
     <artifactId>flyway-core</artifactId>
     <packaging>jar</packaging>

--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -441,7 +441,7 @@ public class Flyway {
      * <p>Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
      * which using the defaults translates to V1_1__My_description.shell</p>
      *
-     * @return The file name suffix for sql migrations. (default: .shell)
+     * @return The file name suffix for shell migrations. (default: .shell)
      */
     public String getShellMigrationSuffix() { return shellMigrationSuffix; }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -174,7 +174,7 @@ public class Flyway {
      * The file name suffix for shell migrations. (default: .sql)
      * <p/>
      * <p>Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
-     * which using the defaults translates to V1_1__My_description.sql</p>
+     * which using the defaults translates to V1_1__My_description.shell</p>
      */
     private String shellMigrationSuffix = ".shell";
 

--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -155,6 +155,30 @@ public class Flyway {
     private String sqlMigrationSuffix = ".sql";
 
     /**
+     * The file name prefix for shell migrations. (default: V)
+     * <p/>
+     * <p>Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.shell</p>
+     */
+    private String shellMigrationPrefix = "V";
+
+    /**
+     * The file name separator for sql migrations. (default: __)
+     * <p/>
+     * <p>Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.shell</p>
+     */
+    private String shellMigrationSeparator = "__";
+
+    /**
+     * The file name suffix for shell migrations. (default: .sql)
+     * <p/>
+     * <p>Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.sql</p>
+     */
+    private String shellMigrationSuffix = ".shell";
+
+    /**
      * Ignores failed future migrations when reading the metadata table. These are migrations that were performed by a
      * newer deployment of the application that are not yet available in this version. For example: we have migrations
      * available on the classpath up to version 3.0. The metadata table indicates that a migration to version 4.0
@@ -390,6 +414,36 @@ public class Flyway {
     public String getSqlMigrationSuffix() {
         return sqlMigrationSuffix;
     }
+
+    /**
+     * Retrieves the file name prefix for shell migrations.
+     * <p/>
+     * <p>Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.shell</p>
+     *
+     * @return The file name prefix for shell migrations. (default: V)
+     */
+    public String getShellMigrationPrefix() { return shellMigrationPrefix; }
+
+    /**
+     * Retrieves the file name separator for shell migrations.
+     * <p/>
+     * <p>Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.shell</p>
+     *
+     * @return The file name separator for shell migrations. (default: __)
+     */
+    public String getShellMigrationSeparator() { return shellMigrationSeparator; }
+
+    /**
+     * Retrieves the file name suffix for shell migrations.
+     * <p/>
+     * <p>Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.shell</p>
+     *
+     * @return The file name suffix for sql migrations. (default: .shell)
+     */
+    public String getShellMigrationSuffix() { return shellMigrationSuffix; }
 
     /**
      * Whether to ignore failed future migrations when reading the metadata table. These are migrations that
@@ -756,6 +810,44 @@ public class Flyway {
      */
     public void setSqlMigrationSuffix(String sqlMigrationSuffix) {
         this.sqlMigrationSuffix = sqlMigrationSuffix;
+    }
+
+    /**
+     * Sets the file name prefix for shell migrations.
+     * <p/>
+     * <p>Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.shell</p>
+     *
+     * @param shellMigrationPrefix The file name prefix for shell migrations (default: V)
+     */
+    public void setShellMigrationPrefix(String shellMigrationPrefix) { this.shellMigrationPrefix = shellMigrationPrefix; }
+
+    /**
+     * Sets the file name separator for shell migrations.
+     * <p/>
+     * <p>Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.shell</p>
+     *
+     * @param shellMigrationSeparator The file name separator for shell migrations (default: __)
+     */
+    public void setShellMigrationSeparator(String shellMigrationSeparator) {
+        if (!StringUtils.hasLength(shellMigrationSeparator)) {
+            throw new FlywayException("shellMigrationSeparator cannot be empty!");
+        }
+
+        this.shellMigrationSeparator = shellMigrationSeparator;
+    }
+
+    /**
+     * Sets the file name suffix for shell migrations.
+     * <p/>
+     * <p>Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.shell</p>
+     *
+     * @param shellMigrationSuffix The file name suffix for shell migrations (default: .shell)
+     */
+    public void setShellMigrationSuffix(String shellMigrationSuffix) {
+        this.shellMigrationSuffix = shellMigrationSuffix;
     }
 
     /**
@@ -1218,7 +1310,9 @@ public class Flyway {
      */
     private MigrationResolver createMigrationResolver(DbSupport dbSupport) {
         return new CompositeMigrationResolver(dbSupport, classLoader, locations,
-                encoding, sqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix, createPlaceholderReplacer(),
+                encoding, sqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix,
+                shellMigrationPrefix, shellMigrationSeparator, shellMigrationSuffix,
+                createPlaceholderReplacer(),
                 resolvers);
     }
 
@@ -1278,6 +1372,18 @@ public class Flyway {
         String sqlMigrationSuffixProp = properties.getProperty("flyway.sqlMigrationSuffix");
         if (sqlMigrationSuffixProp != null) {
             setSqlMigrationSuffix(sqlMigrationSuffixProp);
+        }
+        String shellMigrationPrefixProp = properties.getProperty("flyway.shellMigrationPrefix");
+        if (shellMigrationPrefixProp != null) {
+            setShellMigrationPrefix(shellMigrationPrefixProp);
+        }
+        String shellMigrationSeparatorProp = properties.getProperty("flyway.shellMigrationSeparator");
+        if (shellMigrationSeparatorProp != null) {
+            setShellMigrationSeparator(shellMigrationSeparatorProp);
+        }
+        String shellMigrationSuffixProp = properties.getProperty("flyway.shellMigrationSuffix");
+        if (shellMigrationSuffixProp != null) {
+            setShellMigrationSuffix(shellMigrationSuffixProp);
         }
         String encodingProp = properties.getProperty("flyway.encoding");
         if (encodingProp != null) {

--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -179,6 +179,11 @@ public class Flyway {
     private String shellMigrationSuffix = ".shell";
 
     /**
+     * The args to be passed to shell migrations.
+     */
+    private String shellMigrationArgs = "";
+
+    /**
      * Ignores failed future migrations when reading the metadata table. These are migrations that were performed by a
      * newer deployment of the application that are not yet available in this version. For example: we have migrations
      * available on the classpath up to version 3.0. The metadata table indicates that a migration to version 4.0
@@ -444,6 +449,13 @@ public class Flyway {
      * @return The file name suffix for shell migrations. (default: .shell)
      */
     public String getShellMigrationSuffix() { return shellMigrationSuffix; }
+
+    /**
+     * Retrieves the args to be passed to shell migrations.
+     *
+     * @return The args to be passed to shell migrations
+     */
+    public String getShellMigrationArgs() { return shellMigrationArgs; }
 
     /**
      * Whether to ignore failed future migrations when reading the metadata table. These are migrations that
@@ -848,6 +860,15 @@ public class Flyway {
      */
     public void setShellMigrationSuffix(String shellMigrationSuffix) {
         this.shellMigrationSuffix = shellMigrationSuffix;
+    }
+
+    /**
+     * Sets the arguments to be passed to shell migrations.
+     *
+     * @param shellMigrationArgs The arguments to be passed to shell migrations
+     */
+    public void setShellMigrationArgs(String shellMigrationArgs) {
+        this.shellMigrationArgs = shellMigrationArgs;
     }
 
     /**
@@ -1311,7 +1332,7 @@ public class Flyway {
     private MigrationResolver createMigrationResolver(DbSupport dbSupport) {
         return new CompositeMigrationResolver(dbSupport, classLoader, locations,
                 encoding, sqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix,
-                shellMigrationPrefix, shellMigrationSeparator, shellMigrationSuffix,
+                shellMigrationPrefix, shellMigrationSeparator, shellMigrationSuffix, shellMigrationArgs,
                 createPlaceholderReplacer(),
                 resolvers);
     }
@@ -1384,6 +1405,10 @@ public class Flyway {
         String shellMigrationSuffixProp = properties.getProperty("flyway.shellMigrationSuffix");
         if (shellMigrationSuffixProp != null) {
             setShellMigrationSuffix(shellMigrationSuffixProp);
+        }
+        String shellMigrationArgsProp = properties.getProperty("flyway.shellMigrationArgs");
+        if (shellMigrationArgsProp != null) {
+            setShellMigrationArgs(shellMigrationArgsProp);
         }
         String encodingProp = properties.getProperty("flyway.encoding");
         if (encodingProp != null) {

--- a/flyway-core/src/main/java/org/flywaydb/core/api/migration/shell/ShellMigration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/migration/shell/ShellMigration.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2010-2015 Axel Fontaine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.api.migration.shell;
+
+import java.sql.Connection;
+
+/**
+ * Interface to be implemented by Shell Migrations. By default the migration version and description will be extracted
+ * from the file name. The checksum of this migration (for validation) will also be null.
+ */
+public interface ShellMigration {
+    /**
+     * Executes this migration. The execution will automatically take place within a transaction, when the underlying
+     * database supports it.
+     *
+     * @param connection The connection to use to execute statements.
+     * @throws Exception when the migration failed.
+     */
+    void migrate(Connection connection) throws Exception;
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/api/migration/shell/package-info.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/migration/shell/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2010-2015 Axel Fontaine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Interfaces for Jdbc Migrations.
+ */
+package org.flywaydb.core.api.migration.shell;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
@@ -22,6 +22,7 @@ import org.flywaydb.core.internal.dbsupport.DbSupport;
 import org.flywaydb.core.internal.resolver.jdbc.JdbcMigrationResolver;
 import org.flywaydb.core.internal.resolver.spring.SpringJdbcMigrationResolver;
 import org.flywaydb.core.internal.resolver.sql.SqlMigrationResolver;
+import org.flywaydb.core.internal.resolver.shell.ShellMigrationResolver;
 import org.flywaydb.core.internal.util.FeatureDetector;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.Locations;
@@ -61,18 +62,24 @@ public class CompositeMigrationResolver implements MigrationResolver {
      * @param sqlMigrationPrefix       The file name prefix for sql migrations.
      * @param sqlMigrationSeparator    The file name separator for sql migrations.
      * @param sqlMigrationSuffix       The file name suffix for sql migrations.
+     * @param shellMigrationPrefix     The file name prefix for shell migrations.
+     * @param shellMigrationSeparator  The file name separator for shell migrations.
+     * @param shellMigrationSuffix     The file name suffix for shell migrations.
      * @param placeholderReplacer      The placeholder replacer to use.
      * @param customMigrationResolvers Custom Migration Resolvers.
      */
     public CompositeMigrationResolver(DbSupport dbSupport, ClassLoader classLoader, Locations locations,
                                       String encoding,
                                       String sqlMigrationPrefix, String sqlMigrationSeparator, String sqlMigrationSuffix,
+                                      String shellMigrationPrefix, String shellMigrationSeparator, String shellMigrationSuffix,
                                       PlaceholderReplacer placeholderReplacer,
                                       MigrationResolver... customMigrationResolvers) {
         for (Location location : locations.getLocations()) {
             migrationResolvers.add(new SqlMigrationResolver(dbSupport, classLoader, location, placeholderReplacer,
                     encoding, sqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix));
             migrationResolvers.add(new JdbcMigrationResolver(classLoader, location));
+            migrationResolvers.add(new ShellMigrationResolver(classLoader, location, shellMigrationPrefix,
+                    shellMigrationSeparator, shellMigrationSuffix));
 
             if (new FeatureDetector(classLoader).isSpringJdbcAvailable()) {
                 migrationResolvers.add(new SpringJdbcMigrationResolver(classLoader, location));

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
@@ -65,6 +65,7 @@ public class CompositeMigrationResolver implements MigrationResolver {
      * @param shellMigrationPrefix     The file name prefix for shell migrations.
      * @param shellMigrationSeparator  The file name separator for shell migrations.
      * @param shellMigrationSuffix     The file name suffix for shell migrations.
+     * @param shellMigrationArgs       The arguments to be passed to shell migrations.
      * @param placeholderReplacer      The placeholder replacer to use.
      * @param customMigrationResolvers Custom Migration Resolvers.
      */
@@ -72,6 +73,7 @@ public class CompositeMigrationResolver implements MigrationResolver {
                                       String encoding,
                                       String sqlMigrationPrefix, String sqlMigrationSeparator, String sqlMigrationSuffix,
                                       String shellMigrationPrefix, String shellMigrationSeparator, String shellMigrationSuffix,
+                                      String shellMigrationArgs,
                                       PlaceholderReplacer placeholderReplacer,
                                       MigrationResolver... customMigrationResolvers) {
         for (Location location : locations.getLocations()) {
@@ -79,7 +81,7 @@ public class CompositeMigrationResolver implements MigrationResolver {
                     encoding, sqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix));
             migrationResolvers.add(new JdbcMigrationResolver(classLoader, location));
             migrationResolvers.add(new ShellMigrationResolver(classLoader, location, shellMigrationPrefix,
-                    shellMigrationSeparator, shellMigrationSuffix));
+                    shellMigrationSeparator, shellMigrationSuffix, shellMigrationArgs));
 
             if (new FeatureDetector(classLoader).isSpringJdbcAvailable()) {
                 migrationResolvers.add(new SpringJdbcMigrationResolver(classLoader, location));

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/shell/ShellMigrationExecutor.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/shell/ShellMigrationExecutor.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2010-2015 Axel Fontaine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.resolver.shell;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.resolver.MigrationExecutor;
+import org.flywaydb.core.internal.util.logging.Log;
+import org.flywaydb.core.internal.util.logging.LogFactory;
+import org.flywaydb.core.internal.util.scanner.Resource;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.sql.Connection;
+import java.util.Scanner;
+
+/**
+ * Database migration based on a shell file.
+ */
+public class ShellMigrationExecutor implements MigrationExecutor {
+    private static final Log LOG = LogFactory.getLog(ShellMigrationExecutor.class);
+
+    /**
+     * The Resource pointing to the shell script.
+     * The complete shell script is not held as a member field here because this would use the total size of all
+     * shell migrations files in heap space during db migration, see issue 184.
+     */
+    private final Resource shellScriptResource;
+
+    /**
+     * Creates a new shell script migration based on this shell script.
+     *
+     * @param shellScriptResource   The resource containing the sql script.
+     */
+    public ShellMigrationExecutor(Resource shellScriptResource) {
+        this.shellScriptResource = shellScriptResource;
+    }
+
+    @Override
+    public void execute(Connection connection) {
+        String scriptLocation = this.shellScriptResource.getLocationOnDisk();
+        LOG.info("Executing: " + scriptLocation);
+        try {
+            Process p = Runtime.getRuntime().exec(scriptLocation);
+            inheritIO(p.getInputStream(), System.out);
+            inheritIO(p.getErrorStream(), System.err);
+            p.waitFor();
+            if (p.exitValue() != 0) {
+                LOG.error("Exit value: " + p.exitValue());
+                throw new FlywayException("Unable to apply migration");
+            }
+        }
+        catch (Exception e) {
+            LOG.error(e.toString());
+            throw new FlywayException("Unable to apply migration", e);
+        }
+    }
+
+    private static void inheritIO(final InputStream src, final PrintStream dest) {
+        new Thread(new Runnable() {
+            public void run() {
+                Scanner sc = new Scanner(src);
+                while (sc.hasNextLine()) {
+                    dest.println("> " + sc.nextLine());
+                }
+            }
+        }).start();
+    }
+    @Override
+    public boolean executeInTransaction() {
+        return true;
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/shell/ShellMigrationExecutor.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/shell/ShellMigrationExecutor.java
@@ -42,21 +42,28 @@ public class ShellMigrationExecutor implements MigrationExecutor {
     private final Resource shellScriptResource;
 
     /**
+     * The args to be passed to the shell script.
+     */
+    private final String shellMigrationArgs;
+
+    /**
      * Creates a new shell script migration based on this shell script.
      *
      * @param shellScriptResource   The resource containing the sql script.
      */
-    public ShellMigrationExecutor(Resource shellScriptResource) {
+    public ShellMigrationExecutor(Resource shellScriptResource, String shellMigrationArgs) {
         this.shellScriptResource = shellScriptResource;
+        this.shellMigrationArgs = shellMigrationArgs;
     }
 
     @Override
     public void execute(Connection connection) {
         String scriptLocation = this.shellScriptResource.getLocationOnDisk();
-        LOG.info("Executing: " + scriptLocation);
+        LOG.info("Executing: " + scriptLocation + " " + shellMigrationArgs);
         try {
             List<String> args = new ArrayList<String>();
             args.add(scriptLocation);
+            args.add(shellMigrationArgs);
             ProcessBuilder builder = new ProcessBuilder(args);
             builder.redirectErrorStream(true);
             Process process = builder.start();

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/shell/ShellMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/shell/ShellMigrationResolver.java
@@ -69,6 +69,11 @@ public class ShellMigrationResolver implements MigrationResolver {
     private final String shellMigrationSuffix;
 
     /**
+     * The args to be passed to shell migrations
+     */
+    private final String shellMigrationArgs;
+
+    /**
      * Creates a new instance.
      *
      * @param classLoader             The ClassLoader for loading migrations on the classpath.
@@ -76,14 +81,17 @@ public class ShellMigrationResolver implements MigrationResolver {
      * @param shellMigrationPrefix    The prefix for shell migrations
      * @param shellMigrationSeparator The separator for shell migrations
      * @param shellMigrationSuffix    The suffix for shell migrations
+     * @param shellMigrationArgs      The arguments to be passed to shell migrations
      */
     public ShellMigrationResolver(ClassLoader classLoader, Location location, String shellMigrationPrefix,
-                                  String shellMigrationSeparator, String shellMigrationSuffix) {
+                                  String shellMigrationSeparator, String shellMigrationSuffix,
+                                  String shellMigrationArgs) {
         this.scanner = new Scanner(classLoader);
         this.location = location;
         this.shellMigrationPrefix = shellMigrationPrefix;
         this.shellMigrationSeparator = shellMigrationSeparator;
         this.shellMigrationSuffix = shellMigrationSuffix;
+        this.shellMigrationArgs = shellMigrationArgs;
     }
 
     public List<ResolvedMigration> resolveMigrations() {
@@ -93,7 +101,7 @@ public class ShellMigrationResolver implements MigrationResolver {
         for (Resource resource : resources) {
             ResolvedMigrationImpl resolvedMigration = extractMigrationInfo(resource);
             resolvedMigration.setPhysicalLocation(resource.getLocationOnDisk());
-            resolvedMigration.setExecutor(new ShellMigrationExecutor(resource));
+            resolvedMigration.setExecutor(new ShellMigrationExecutor(resource, shellMigrationArgs));
 
             migrations.add(resolvedMigration);
         }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/shell/ShellMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/shell/ShellMigrationResolver.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2010-2015 Axel Fontaine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.resolver.shell;
+
+import org.flywaydb.core.api.MigrationType;
+import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.resolver.MigrationResolver;
+import org.flywaydb.core.api.resolver.ResolvedMigration;
+import org.flywaydb.core.internal.dbsupport.DbSupport;
+import org.flywaydb.core.internal.resolver.MigrationInfoHelper;
+import org.flywaydb.core.internal.resolver.ResolvedMigrationComparator;
+import org.flywaydb.core.internal.resolver.ResolvedMigrationImpl;
+import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.logging.Log;
+import org.flywaydb.core.internal.util.logging.LogFactory;
+import org.flywaydb.core.internal.util.Pair;
+import org.flywaydb.core.internal.util.PlaceholderReplacer;
+import org.flywaydb.core.internal.util.scanner.Resource;
+import org.flywaydb.core.internal.util.scanner.Scanner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.zip.CRC32;
+
+/**
+ * Migration resolver for shell files on the classpath. The shell files must have names like
+ * V1__Description.shell or V1_1__Description.shell.
+ */
+public class ShellMigrationResolver implements MigrationResolver {
+    private static final Log LOG = LogFactory.getLog(ShellMigrationResolver.class);
+
+    /**
+     * The scanner to use.
+     */
+    private final Scanner scanner;
+
+    /**
+     * The base directory on the classpath where to migrations are located.
+     */
+    private final Location location;
+
+    /**
+     * The prefix for shell migrations
+     */
+    private final String shellMigrationPrefix;
+
+    /**
+     * The separator for shell migrations
+     */
+    private final String shellMigrationSeparator;
+
+    /**
+     * The suffix for shell migrations
+     */
+    private final String shellMigrationSuffix;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param classLoader             The ClassLoader for loading migrations on the classpath.
+     * @param location                The location on the classpath where to migrations are located.
+     * @param shellMigrationPrefix    The prefix for shell migrations
+     * @param shellMigrationSeparator The separator for shell migrations
+     * @param shellMigrationSuffix    The suffix for shell migrations
+     */
+    public ShellMigrationResolver(ClassLoader classLoader, Location location, String shellMigrationPrefix,
+                                  String shellMigrationSeparator, String shellMigrationSuffix) {
+        this.scanner = new Scanner(classLoader);
+        this.location = location;
+        this.shellMigrationPrefix = shellMigrationPrefix;
+        this.shellMigrationSeparator = shellMigrationSeparator;
+        this.shellMigrationSuffix = shellMigrationSuffix;
+    }
+
+    public List<ResolvedMigration> resolveMigrations() {
+        List<ResolvedMigration> migrations = new ArrayList<ResolvedMigration>();
+
+        Resource[] resources = scanner.scanForResources(location, shellMigrationPrefix, shellMigrationSuffix);
+        for (Resource resource : resources) {
+            ResolvedMigrationImpl resolvedMigration = extractMigrationInfo(resource);
+            resolvedMigration.setPhysicalLocation(resource.getLocationOnDisk());
+            resolvedMigration.setExecutor(new ShellMigrationExecutor(resource));
+
+            migrations.add(resolvedMigration);
+        }
+
+        Collections.sort(migrations, new ResolvedMigrationComparator());
+        return migrations;
+    }
+
+    /**
+     * Extracts the migration info for this resource.
+     *
+     * @param resource The resource to analyse.
+     * @return The migration info.
+     */
+    private ResolvedMigrationImpl extractMigrationInfo(Resource resource) {
+        ResolvedMigrationImpl migration = new ResolvedMigrationImpl();
+
+        Pair<MigrationVersion, String> info =
+                MigrationInfoHelper.extractVersionAndDescription(resource.getFilename(),
+                        shellMigrationPrefix, shellMigrationSeparator, shellMigrationSuffix);
+        migration.setVersion(info.getLeft());
+        migration.setDescription(info.getRight());
+
+        migration.setScript(extractScriptName(resource));
+
+        migration.setChecksum(calculateChecksum(resource.loadAsBytes()));
+        migration.setType(MigrationType.SQL);
+        return migration;
+    }
+
+    /**
+     * Extracts the script name from this resource.
+     *
+     * @param resource The resource to process.
+     * @return The script name.
+     */
+    /* private -> for testing */ String extractScriptName(Resource resource) {
+        if (location.getPath().isEmpty()) {
+            return resource.getLocation();
+        }
+
+        return resource.getLocation().substring(location.getPath().length() + 1);
+    }
+
+    /**
+     * Calculates the checksum of these bytes.
+     *
+     * @param bytes The bytes to calculate the checksum for.
+     * @return The crc-32 checksum of the bytes.
+     */
+    private static int calculateChecksum(byte[] bytes) {
+        final CRC32 crc32 = new CRC32();
+        crc32.update(bytes);
+        return (int) crc32.getValue();
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/shell/package-info.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/shell/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2010-2015 Axel Fontaine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Private API. No compatibility guarantees provided.
+ */
+package org.flywaydb.core.internal.resolver.shell;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/VersionPrinter.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/VersionPrinter.java
@@ -42,6 +42,6 @@ public class VersionPrinter {
         }
         printed = true;
         String version = new ClassPathResource("org/flywaydb/core/internal/version.txt", classLoader).loadAsString("UTF-8");
-        LOG.info("Flyway " + version + " by Boxfuse XXX");
+        LOG.info("Flyway " + version + " by Boxfuse");
     }
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/VersionPrinter.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/VersionPrinter.java
@@ -42,6 +42,6 @@ public class VersionPrinter {
         }
         printed = true;
         String version = new ClassPathResource("org/flywaydb/core/internal/version.txt", classLoader).loadAsString("UTF-8");
-        LOG.info("Flyway " + version + " by Boxfuse");
+        LOG.info("Flyway " + version + " by Boxfuse XXX");
     }
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
@@ -42,7 +42,7 @@ public class CompositeMigrationResolverSmallTest {
         MigrationResolver migrationResolver = new CompositeMigrationResolver(null,
                 Thread.currentThread().getContextClassLoader(),
                 new Locations("migration/subdir/dir2", "migration.outoforder", "migration/subdir/dir1"),
-                "UTF-8", "V", "__", ".sql", placeholderReplacer, new MyCustomMigrationResolver());
+                "UTF-8", "V", "__", ".sql", "V", "__", ".shell", placeholderReplacer, new MyCustomMigrationResolver());
 
         Collection<ResolvedMigration> migrations = migrationResolver.resolveMigrations();
         List<ResolvedMigration> migrationList = new ArrayList<ResolvedMigration>(migrations);

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
@@ -42,7 +42,7 @@ public class CompositeMigrationResolverSmallTest {
         MigrationResolver migrationResolver = new CompositeMigrationResolver(null,
                 Thread.currentThread().getContextClassLoader(),
                 new Locations("migration/subdir/dir2", "migration.outoforder", "migration/subdir/dir1"),
-                "UTF-8", "V", "__", ".sql", "V", "__", ".shell", placeholderReplacer, new MyCustomMigrationResolver());
+                "UTF-8", "V", "__", ".sql", "V", "__", ".shell", "", placeholderReplacer, new MyCustomMigrationResolver());
 
         Collection<ResolvedMigration> migrations = migrationResolver.resolveMigrations();
         List<ResolvedMigration> migrationList = new ArrayList<ResolvedMigration>(migrations);

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/util/jdbc/DriverDataSourceSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/util/jdbc/DriverDataSourceSmallTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010-2015 Axel Fontaine
- * <p/>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/util/jdbc/DriverDataSourceSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/util/jdbc/DriverDataSourceSmallTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010-2015 Axel Fontaine
- *
+ * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/flyway-gradle-plugin-largetest/pom.xml
+++ b/flyway-gradle-plugin-largetest/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>3.2.1-rollbar1</version>
     </parent>
     <artifactId>flyway-gradle-plugin-largetest</artifactId>
     <packaging>jar</packaging>

--- a/flyway-gradle-plugin/pom.xml
+++ b/flyway-gradle-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>3.2.1-rollbar1</version>
     </parent>
     <artifactId>flyway-gradle-plugin</artifactId>
     <packaging>jar</packaging>
@@ -75,7 +75,7 @@
                         </goals>
                         <configuration>
                             <tasks>
-                                <copy file="${basedir}/build/libs/flyway-gradle-plugin-${project.version}.jar" todir="target" overwrite="true"/>
+                                <copy file="${basedir}/build/libs/flyway-gradle-plugin-${project.version}.jar" todir="target" overwrite="true" />
                             </tasks>
                         </configuration>
                     </execution>

--- a/flyway-gradle-plugin/src/main/groovy/org/flywaydb/gradle/FlywayExtension.groovy
+++ b/flyway-gradle-plugin/src/main/groovy/org/flywaydb/gradle/FlywayExtension.groovy
@@ -107,6 +107,30 @@ public class FlywayExtension {
      */
     String sqlMigrationSuffix
 
+    /**
+     * The file name prefix for shell migrations
+     *
+     * <p>Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.shell</p>
+     */
+    String shellMigrationPrefix
+
+    /**
+     * The file name separator for shell migrations
+     *
+     * <p>Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.shell</p>
+     */
+    String shellMigrationSeparator
+
+    /**
+     * The file name suffix for shell migrations
+     *
+     * <p>Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.shell</p>
+     */
+    String shellMigrationSuffix
+
     /** The encoding of Sql migrations */
     String encoding
 

--- a/flyway-gradle-plugin/src/main/groovy/org/flywaydb/gradle/FlywayExtension.groovy
+++ b/flyway-gradle-plugin/src/main/groovy/org/flywaydb/gradle/FlywayExtension.groovy
@@ -131,6 +131,9 @@ public class FlywayExtension {
      */
     String shellMigrationSuffix
 
+    /** The args to be passed to shell migrations */
+    String shellMigrationArgs
+
     /** The encoding of Sql migrations */
     String encoding
 

--- a/flyway-maven-plugin-largetest/pom.xml
+++ b/flyway-maven-plugin-largetest/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>3.2.1-rollbar1</version>
     </parent>
     <artifactId>flyway-maven-plugin-largetest</artifactId>
     <packaging>jar</packaging>

--- a/flyway-maven-plugin/pom.xml
+++ b/flyway-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>3.2.1-rollbar1</version>
     </parent>
     <artifactId>flyway-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>

--- a/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
+++ b/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
@@ -224,6 +224,39 @@ abstract class AbstractFlywayMojo extends AbstractMojo {
     private String sqlMigrationSuffix = flyway.getSqlMigrationSuffix();
 
     /**
+     * The file name prefix for shell migrations (default: V) <p>Also configurable with Maven or System Property:
+     * ${flyway.shellMigrationPrefix}</p>
+     *
+     * <p>Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.shell</p>
+     *
+     * @parameter property="flyway.shellMigrationPrefix"
+     */
+    private String shellMigrationPrefix = flyway.getShellMigrationPrefix();
+
+    /**
+     * The file name separator for shell migrations (default: __) <p>Also configurable with Maven or System Property:
+     * ${flyway.shellMigrationSeparator}</p>
+     *
+     * <p>Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.shell</p>
+     *
+     * @parameter property="flyway.shellMigrationSeparator"
+     */
+    private String shellMigrationSeparator = flyway.getShellMigrationSeparator();
+
+    /**
+     * The file name suffix for shell migrations (default: .shell) <p>Also configurable with Maven or System Property:
+     * ${flyway.shellMigrationSuffix}</p>
+     *
+     * <p>Shell migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.shell</p>
+     *
+     * @parameter property="flyway.shellMigrationSuffix"
+     */
+    private String shellMigrationSuffix = flyway.getShellMigrationSuffix();
+
+    /**
      * Whether to automatically call clean or not when a validation error occurs. (default: {@code false})<br/>
      * <p> This is exclusively intended as a convenience for development. Even tough we
      * strongly recommend not to change migration scripts once they have been checked into SCM and run, this provides a
@@ -482,6 +515,9 @@ abstract class AbstractFlywayMojo extends AbstractMojo {
             flyway.setSqlMigrationPrefix(sqlMigrationPrefix);
             flyway.setSqlMigrationSeparator(sqlMigrationSeparator);
             flyway.setSqlMigrationSuffix(sqlMigrationSuffix);
+            flyway.setShellMigrationPrefix(shellMigrationPrefix);
+            flyway.setShellMigrationSeparator(shellMigrationSeparator);
+            flyway.setShellMigrationSuffix(shellMigrationSuffix);
             flyway.setCleanOnValidationError(cleanOnValidationError);
             flyway.setOutOfOrder(outOfOrder);
             flyway.setTargetAsString(target);

--- a/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
+++ b/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
@@ -257,6 +257,14 @@ abstract class AbstractFlywayMojo extends AbstractMojo {
     private String shellMigrationSuffix = flyway.getShellMigrationSuffix();
 
     /**
+     * The arguments to be passed to shell migrations <p>Also configurable with Maven or System Property:
+     * ${flyway.shellMigrationArgs}</p>
+     *
+     * @parameter property="flyway.shellMigrationArgs"
+     */
+    private String shellMigrationArgs = flyway.getShellMigrationArgs();
+
+    /**
      * Whether to automatically call clean or not when a validation error occurs. (default: {@code false})<br/>
      * <p> This is exclusively intended as a convenience for development. Even tough we
      * strongly recommend not to change migration scripts once they have been checked into SCM and run, this provides a

--- a/flyway-osgi-largetest/pom.xml
+++ b/flyway-osgi-largetest/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>3.2.1-rollbar1</version>
     </parent>
     <artifactId>flyway-osgi-largetest</artifactId>
     <packaging>jar</packaging>

--- a/flyway-sample-osgi-fragment/pom.xml
+++ b/flyway-sample-osgi-fragment/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>3.2.1-rollbar1</version>
     </parent>
     <artifactId>flyway-sample-osgi-fragment</artifactId>
     <packaging>jar</packaging>

--- a/flyway-sample-osgi/pom.xml
+++ b/flyway-sample-osgi/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>3.2.1-rollbar1</version>
     </parent>
     <artifactId>flyway-sample-osgi</artifactId>
     <packaging>jar</packaging>

--- a/flyway-sample-webapp/pom.xml
+++ b/flyway-sample-webapp/pom.xml
@@ -3,10 +3,10 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>3.2.1-rollbar1</version>
     </parent>
     <artifactId>flyway-sample-webapp</artifactId>
-    <version>0-SNAPSHOT</version>
+    <version>3.2.1-rollbar1</version>
     <packaging>war</packaging>
     <name>${project.artifactId}</name>
     <dependencies>

--- a/flyway-sample/pom.xml
+++ b/flyway-sample/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>3.2.1-rollbar1</version>
     </parent>
     <artifactId>flyway-sample</artifactId>
     <packaging>jar</packaging>

--- a/flyway-sbt-largetest/pom.xml
+++ b/flyway-sbt-largetest/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>3.2.1-rollbar1</version>
     </parent>
     <artifactId>flyway-sbt-largetest</artifactId>
     <packaging>jar</packaging>

--- a/flyway-sbt/pom.xml
+++ b/flyway-sbt/pom.xml
@@ -1,13 +1,12 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>3.2.1-rollbar1</version>
     </parent>
     <artifactId>flyway-sbt</artifactId>
-    <version>0-SNAPSHOT</version>
+    <version>3.2.1-rollbar1</version>
     <packaging>pom</packaging>
     <name>${project.artifactId}</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <!--
     Detailed information how to contribute: http://flywaydb.org/contribute/code/
 
@@ -26,7 +25,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.flywaydb</groupId>
     <artifactId>flyway-parent</artifactId>
-    <version>0-SNAPSHOT</version>
+    <version>3.2.1-rollbar1</version>
     <packaging>pom</packaging>
     <name>${project.artifactId}</name>
     <description>


### PR DESCRIPTION
Adds functionality to let you:
- Drop a file into the "scripts" directory with a ".shell" suffix (location and suffix are configurable)
- Make sure it's executable
- Run 'flyway migrate' and have the script run to perform the corresponding migration

This lets you run Python scripts, for example (or more specifically a shell script that wraps a Python program) and migration via SQLAlchemy ORM or your own app's logic.

The script migration will fail if the script can't be executed (e.g. permission denied) or returns an exit code other than 0.

Note that there are no tests for this new functionality yet, as it's not clear how to do so in a cross-platform compatible way.

See https://github.com/flyway/flyway/issues/1086 for discussion.
